### PR TITLE
fix: skip prepublishOnly in CI publish job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -144,6 +144,6 @@ jobs:
         run: npx tsc
 
       - name: Publish (dry run)
-        run: npm publish --dry-run
+        run: npm publish --dry-run --ignore-scripts
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
The publish runner is Linux but `prepublishOnly` runs `cargo build` which tries to copy a macOS dylib. Add `--ignore-scripts` since binaries are already downloaded as artifacts.