### PR TITLE
fix: accept Windows backslash paths in stdio entrypoint detection

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,6 +32,8 @@
   "files": [
     "dist/server.js",
     "dist/server.d.ts",
+    "dist/entrypoint.js",
+    "dist/entrypoint.d.ts",
     "dist/client.js",
     "dist/client.d.ts",
     "dist/session.js",

--- a/src/entrypoint.ts
+++ b/src/entrypoint.ts
@@ -1,0 +1,27 @@
+/**
+ * Standalone stdio entrypoint detection.
+ *
+ * Determines whether the current Node process was invoked as the
+ * computer-use-mcp stdio server (e.g. `node dist/server.js` or
+ * `npx @zavora-ai/computer-use-mcp`) vs imported as a library.
+ *
+ * Path-separator-agnostic: Node normalizes `process.argv[1]` to the platform
+ * separator, so a hard-coded `/` check rejects valid Windows invocations like
+ * `C:\path\to\server.js`. Without this, the server silently exits without
+ * starting StdioServerTransport on every Windows host.
+ *
+ * Kept in its own module (no native imports) so the helper is unit-testable
+ * without building the Rust NAPI binary.
+ */
+export function isStdioEntrypoint(argv1: string | undefined): boolean {
+  if (!argv1) return false
+  // Normalize backslashes to forward slashes once, then match against the
+  // POSIX-style suffixes. Cheaper and clearer than checking both separators
+  // for every suffix.
+  const normalized = argv1.replace(/\\/g, '/')
+  return (
+    normalized.endsWith('/server.ts') ||
+    normalized.endsWith('/server.js') ||
+    normalized.endsWith('/computer-use-mcp')
+  )
+}

--- a/src/server.ts
+++ b/src/server.ts
@@ -8,6 +8,7 @@ import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js'
 import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js'
 import { z, ZodTypeAny } from 'zod'
 import { createSession, type Session, type SessionOptions } from './session.js'
+import { isStdioEntrypoint } from './entrypoint.js'
 
 /**
  * v5.2 — How each tool reaches the target app.
@@ -409,8 +410,9 @@ export function createComputerUseServer(opts: ServerOptions = {}): McpServer {
   return server
 }
 
-// Standalone stdio entrypoint
-if (process.argv[1]?.endsWith('/server.ts') || process.argv[1]?.endsWith('/server.js') || process.argv[1]?.endsWith('/computer-use-mcp')) {
+// Standalone stdio entrypoint. Detection lives in ./entrypoint.ts so it is
+// unit-testable without loading the native NAPI binary.
+if (isStdioEntrypoint(process.argv[1])) {
   const server = createComputerUseServer()
   const transport = new StdioServerTransport()
   server.connect(transport).then(() => console.error('[computer-use-mcp] Server running'))

--- a/test/entrypoint-detection.test.mjs
+++ b/test/entrypoint-detection.test.mjs
@@ -1,0 +1,49 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+import { isStdioEntrypoint } from '../dist/entrypoint.js'
+
+// Regression: prior to this fix, the standalone entrypoint guard used
+// `endsWith('/server.js')` and friends — broken on Windows where Node
+// normalizes process.argv[1] to use backslashes. The server silently exited
+// without starting StdioServerTransport, breaking `node dist/server.js` and
+// `npx @zavora-ai/computer-use-mcp` on every Windows host.
+
+test('isStdioEntrypoint accepts POSIX-style server.js path', () => {
+  assert.equal(isStdioEntrypoint('/usr/local/bin/server.js'), true)
+  assert.equal(isStdioEntrypoint('/home/user/project/dist/server.js'), true)
+})
+
+test('isStdioEntrypoint accepts Windows-style server.js path', () => {
+  assert.equal(isStdioEntrypoint('C:\\Users\\Jeff\\node_modules\\@zavora-ai\\computer-use-mcp\\dist\\server.js'), true)
+  assert.equal(isStdioEntrypoint('D:\\projects\\app\\dist\\server.js'), true)
+})
+
+test('isStdioEntrypoint accepts POSIX-style server.ts path (tsx dev mode)', () => {
+  assert.equal(isStdioEntrypoint('/repo/src/server.ts'), true)
+})
+
+test('isStdioEntrypoint accepts Windows-style server.ts path (tsx dev mode)', () => {
+  assert.equal(isStdioEntrypoint('C:\\repo\\src\\server.ts'), true)
+})
+
+test('isStdioEntrypoint accepts POSIX-style bin-name path', () => {
+  assert.equal(isStdioEntrypoint('/usr/local/bin/computer-use-mcp'), true)
+})
+
+test('isStdioEntrypoint accepts Windows-style bin-name path', () => {
+  assert.equal(isStdioEntrypoint('C:\\Users\\Jeff\\AppData\\Roaming\\npm\\computer-use-mcp'), true)
+})
+
+test('isStdioEntrypoint rejects unrelated entry points', () => {
+  assert.equal(isStdioEntrypoint('/usr/local/bin/client.js'), false)
+  assert.equal(isStdioEntrypoint('C:\\repo\\dist\\demo.js'), false)
+  assert.equal(isStdioEntrypoint('/path/to/some-other-tool'), false)
+})
+
+test('isStdioEntrypoint handles undefined argv[1] gracefully', () => {
+  assert.equal(isStdioEntrypoint(undefined), false)
+})
+
+test('isStdioEntrypoint handles empty string gracefully', () => {
+  assert.equal(isStdioEntrypoint(''), false)
+})


### PR DESCRIPTION
## Summary

The standalone stdio-entrypoint guard in `src/server.ts` uses `endsWith('/server.js')` (and two sibling suffix checks). On Windows, Node normalizes `process.argv[1]` to use backslashes, so the check **always returns `false`** and the server silently exits without starting `StdioServerTransport`.

This breaks every Windows invocation of `@zavora-ai/computer-use-mcp` 6.x — `node dist/server.js`, `npx @zavora-ai/computer-use-mcp`, Claude Code via `.mcp.json`, etc. — even though `package.json` declares `os: ["darwin", "win32"]` and the README documents Windows support.

## Repro

```powershell
> node .\dist\server.js
# (exits with code 0 after ~1 second, no stdout, no stderr)
```

Same result with `npx --yes @zavora-ai/computer-use-mcp`. Claude Code / any MCP host sits at the `initialize` handshake until its 30 s timeout fires.

## Root cause

```ts
// src/server.ts:413 (before)
if (process.argv[1]?.endsWith('/server.ts') ||
    process.argv[1]?.endsWith('/server.js') ||
    process.argv[1]?.endsWith('/computer-use-mcp')) {
  // start StdioServerTransport
}
```

Quick check on Windows confirms the normalization is one-way:

```js
// node "C:/Users/foo/dist/server.js"
console.log(JSON.stringify(process.argv[1]))
// → "C:\Users\foo\dist\server.js"   (always backslash, regardless of input)
```

So `endsWith('/server.js')` is structurally unreachable on Windows.

## Fix

Extract the check into `src/entrypoint.ts` as `isStdioEntrypoint(argv1)`, normalize backslashes to forward slashes once, then run the same three suffix checks. The helper lives in its own module (no `./native.js` import) so it is unit-testable without building the Rust NAPI binary — important because the existing test suite is unrunnable on a Windows machine that has not run `npm run build:native:win`.

Also adds `dist/entrypoint.{js,d.ts}` to the `files` allowlist so the helper ships in the published package.

## Test plan

- [x] `npm run build:ts` — clean
- [x] `node --test test/entrypoint-detection.test.mjs` — 9/9 pass (POSIX server.js, Windows server.js, server.ts, computer-use-mcp bin, negative cases, undefined, empty string)
- [x] Manual Windows smoke: `node dist/server.js` no longer exits silently. After the fix it reaches the native-binary load step (which then fails because the `.node` artifact is not in the local checkout — separate, expected pre-existing limitation for source-only builds). On a machine using the published npm package (which includes prebuilt `.node` files), the server will fully start.
- [ ] CI matrix (macOS arm64, macOS x64, Windows x64) — let the existing workflow run.

## Why this matters

Claude Code's desktop-control agent (and any third-party tool wiring computer-use-mcp via `.mcp.json` on Windows) is currently a no-op against 6.x — the proxy spawns the npx subprocess, the subprocess exits silently inside a second, and the MCP host sees no tools. Until 6.2 ships, downstream projects have to fork or in-place-patch `node_modules`.

## Notes

- Did not touch `package-lock.json` even though `npm install` rewrites the embedded version field — that drift is unrelated to this fix and would muddy the diff.
- No source comments removed; the new comment on the entrypoint block is a forward-reference to the helper.