### PR TITLE
feat: add native Linux support (X11 + Wayland)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,6 +32,11 @@ jobs:
             rust-target: x86_64-pc-windows-msvc
             artifact: computer-use-napi.win32-x64.node
             copy-from: target/x86_64-pc-windows-msvc/release/computer_use_napi.dll
+          - name: Linux x64
+            runner: ubuntu-latest
+            rust-target: x86_64-unknown-linux-gnu
+            artifact: computer-use-napi.linux-x64.node
+            copy-from: target/x86_64-unknown-linux-gnu/release/libcomputer_use_napi.so
     steps:
       - uses: actions/checkout@v4
 
@@ -39,6 +44,10 @@ jobs:
         uses: dtolnay/rust-toolchain@stable
         with:
           targets: ${{ matrix.target.rust-target }}
+
+      - name: Install Linux dependencies
+        if: runner.os == 'Linux'
+        run: sudo apt-get update && sudo apt-get install -y pkg-config libx11-dev libxtst-dev libxrandr-dev
 
       - name: Rust cache
         uses: Swatinem/rust-cache@v2
@@ -74,6 +83,9 @@ jobs:
           - name: Windows x64
             runner: windows-latest
             binary: computer-use-napi.win32-x64.node
+          - name: Linux x64
+            runner: ubuntu-latest
+            binary: computer-use-napi.linux-x64.node
     steps:
       - uses: actions/checkout@v4
 
@@ -105,6 +117,10 @@ jobs:
       - name: Run smoke test (Windows)
         if: runner.os == 'Windows'
         run: node test/smoke-windows.mjs
+
+      - name: Run smoke test (Linux)
+        if: runner.os == 'Linux'
+        run: node -e "const { loadNative } = await import('./dist/native.js'); const n = loadNative(); console.log('Native module loaded:', Object.keys(n).length, 'functions')"
 
       - name: Run new tools smoke test
         run: node test/smoke-new-tools.mjs
@@ -139,6 +155,7 @@ jobs:
           test -f computer-use-napi.darwin-arm64.node
           test -f computer-use-napi.darwin-x64.node
           test -f computer-use-napi.win32-x64.node
+          test -f computer-use-napi.linux-x64.node
 
       - name: Build TypeScript
         run: npx tsc

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,6 @@
 # Using computer-use-mcp with AI Agents
 
-This guide covers how to integrate `computer-use-mcp` into AI agent frameworks and agentic workflows. Works on both **macOS** and **Windows**.
+This guide covers how to integrate `computer-use-mcp` into AI agent frameworks and agentic workflows. Works on **macOS**, **Windows**, and **Linux**.
 
 ## Tool priority guidance
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,32 @@
 # Changelog
 
+## v6.1.1 (2026-05-16)
+
+v6.1.1 adds **native Linux support** (X11 + Wayland), making computer-use-mcp a true cross-platform desktop automation server for macOS, Windows, and Linux.
+
+### Linux native modules (Rust)
+- **Mouse** — X11/XTest for X11 sessions, `ydotool` for Wayland. Absolute positioning, click, drag, scroll
+- **Keyboard** — X11/XTest keycodes for X11, `ydotool` evdev keycodes for Wayland. Full key map with combos
+- **Text input** — `xdotool type` (X11) or `ydotool type` (Wayland) for reliable Unicode text entry
+- **Screenshot** — XDG Desktop Portal (GNOME Wayland), `gnome-screenshot`, `grim` (wlroots), `scrot` (X11 fallback)
+- **Clipboard** — `wl-copy`/`wl-paste` on Wayland, `xclip`/`xsel` on X11
+- **Window management** — GNOME Shell D-Bus Eval for Wayland, `wmctrl`/`xdotool` for X11
+- **App management** — `/proc` filesystem + `wmctrl` + GNOME D-Bus for listing, activation, hide/unhide
+- **Display** — X11 `XDisplayWidth`/`XDisplayHeight` for resolution and multi-screen
+- **Workspaces** — `wmctrl -d` for listing, `wmctrl -t` for moving windows between desktops
+- **Accessibility** — Stubs (AT-SPI2 integration planned for future release)
+- **Scripting** — `bash` by default, `pwsh` if installed
+
+### Wayland-native support
+- Runtime detection via `XDG_SESSION_TYPE` environment variable
+- Automatic fallback: Wayland tools → X11/XWayland tools
+- Tested on GNOME 50 (Ubuntu 25.04) with Wayland session
+
+### Platform detection
+- `src/native.ts` — added `linux-x64` and `linux-arm64` targets
+- `src/session.ts` — `IS_LINUX` constant, Linux-specific clipboard, scripting, and keyboard handling
+- All Linux code gated behind `#[cfg(target_os = "linux")]` — zero impact on macOS/Windows
+
 ## v6.0.0 (2026-04-26)
 
 v6.0 adds **native Windows support**, transforming computer-use-mcp from a macOS-only tool into a cross-platform desktop automation server. Every Windows API call goes through Rust via `windows-rs` with zero-overhead NAPI bindings — no Python, no pywin32, no subprocess overhead.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -29,6 +29,22 @@ node test/smoke-windows.mjs # verify everything works
 - Visual Studio Build Tools (C++ workload) or Visual Studio with C++ support
 - Windows SDK (included with VS Build Tools)
 
+### Linux
+```bash
+git clone https://github.com/zavora-ai/computer-use-mcp
+cd computer-use-mcp
+npm install
+npm run build:native:linux  # builds Rust native module
+npm run build:ts             # compiles TypeScript
+```
+
+**Linux prerequisites:**
+- [Rust](https://rustup.rs) (stable, 1.70+)
+- [Node.js](https://nodejs.org) 18+
+- X11 dev libraries: `sudo apt-get install -y pkg-config libx11-dev libxtst-dev libxrandr-dev`
+- Runtime tools: `sudo apt-get install -y xdotool wmctrl xclip scrot`
+- For Wayland: `sudo apt-get install -y wl-clipboard ydotool grim`
+
 ## Project structure
 
 ```

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 > Computer Use MCP is an open source high performance MCP server + client for controlling your desktop computer with AI Agents. Tools include screenshot, mouse, keyboard, clipboard, app management, and window-level targeting — all in-process via Rust NAPI. Easy to install via npm and works with Claude Code, Claude DEsktop, Codex CLi, Codex Desktop, Gemnini Cli, Kiro CLi, Kiro VS Code Extension, Github Copilot, Cursor, OpenCode, OpenClaw, Hermes Agent and any other provider that supports Model Context Protocol.
 
-**macOS + Windows** · Node.js 18+ · MIT License
+**macOS + Windows + Linux** · Node.js 18+ · MIT License
 
 ---
 
@@ -37,7 +37,7 @@
 
 `computer-use-mcp` lets an AI model (or any program) control your computer — take screenshots, move the mouse, type text, press keys, read/write the clipboard, open and manage apps, target specific windows, and query display information.
 
-It works on both **macOS** and **Windows**, with platform-specific native implementations backed by a Rust NAPI module. On macOS it uses CoreGraphics/AppKit/AXUIElement; on Windows it uses SendInput/EnumWindows/IUIAutomation/DXGI — all direct Win32 API calls through Rust, no Python dependencies.
+It works on **macOS**, **Windows**, and **Linux**, with platform-specific native implementations backed by a Rust NAPI module. On macOS it uses CoreGraphics/AppKit/AXUIElement; on Windows it uses SendInput/EnumWindows/IUIAutomation/DXGI — all direct Win32 API calls through Rust, no Python dependencies. On Linux it uses X11/XTest for input synthesis, xdotool/wmctrl for window management, and scrot for screenshots.
 
 It implements the [Model Context Protocol (MCP)](https://modelcontextprotocol.io), which means any MCP-compatible AI client (Claude Desktop, Cursor, Windsurf, etc.) can use it as a tool server with zero extra code.
 
@@ -91,6 +91,20 @@ This package takes a different approach: a **Rust native module** (`.node` addon
 | Clipboard | `OpenClipboard` / `SetClipboardData` (native Win32) |
 | UI Automation | `IUIAutomation` COM (direct vtable calls from Rust) |
 
+**Linux:**
+
+| What | How |
+|---|---|
+| Mouse & keyboard | X11/XTest (X11) or `ydotool` (Wayland) — direct synthetic events |
+| Text input | `xdotool type` (X11) or `ydotool type` (Wayland) — Unicode support |
+| App management | `/proc` filesystem + `wmctrl` + GNOME Shell D-Bus |
+| Window enumeration | `wmctrl` (X11) or GNOME Shell D-Bus Eval (Wayland) |
+| Window activation | `xdotool windowactivate` (X11) or GNOME D-Bus (Wayland) |
+| Display info | X11 `XDisplayWidth`/`XDisplayHeight` |
+| Screenshots | XDG Desktop Portal (GNOME Wayland), `grim` (wlroots), `scrot` (X11) |
+| Clipboard | `wl-copy`/`wl-paste` (Wayland) or `xclip`/`xsel` (X11) |
+| Workspaces | `wmctrl -d` for listing, `wmctrl -t` for moving windows |
+
 Mouse, keyboard, focus, window enumeration, and display operations run in-process via the native module. Screenshots and clipboard access still rely on the system utilities that are most reliable on macOS, but the control path avoids per-action shell hops.
 
 ---
@@ -101,7 +115,7 @@ Mouse, keyboard, focus, window enumeration, and display operations run in-proces
 
 | Feature | computer-use-mcp (ours) | CursorTouch/Windows-MCP | sinmb79/windows-computer-mcp | Claude Computer Use | OpenAI CUA |
 |---|---|---|---|---|---|
-| **Platform** | macOS + Windows | Windows only | Windows only | Linux (Docker) | Linux (Docker) |
+| **Platform** | macOS + Windows + Linux | Windows only | Windows only | Linux (Docker) | Linux (Docker) |
 | **Language** | Rust NAPI + TypeScript | Python | Python | Python (reference) | Python (reference) |
 | **Protocol** | MCP (stdio + in-process) | MCP (stdio) | MCP (stdio) | Claude API built-in | OpenAI API built-in |
 | **Tools** | 58 | 14 | 10 | 3 (computer, bash, editor) | 1 (computer) |
@@ -277,6 +291,19 @@ No special permissions are required for most operations on Windows. The native m
 **Notes:**
 - UI Automation access may be blocked by UIPI (User Interface Privilege Isolation) when targeting elevated processes. Run your terminal as Administrator if you need to automate elevated apps.
 - No Python, pywin32, or any Python dependencies are required — everything is implemented in Rust.
+
+### Linux
+
+No special permissions are required beyond having an X11 display available. Ensure the following tools are installed:
+
+```bash
+sudo apt-get install -y xdotool wmctrl xclip scrot
+```
+
+**Notes:**
+- XTest extension must be enabled (it is by default on most X11 setups).
+- For Wayland sessions, you may need to run under XWayland or set `GDK_BACKEND=x11`.
+- No Python dependencies required — the native module uses Rust + X11 directly.
 
 ---
 
@@ -861,6 +888,45 @@ npm run build:ts            # compiles TypeScript
 node test/smoke-windows.mjs # verify
 ```
 
+### Linux
+
+You need:
+- [Rust](https://rustup.rs) (stable, 1.70+)
+- [Node.js](https://nodejs.org) 18+
+- X11 development libraries and tools
+
+```bash
+# Install dependencies (Ubuntu/Debian)
+sudo apt-get install -y pkg-config libx11-dev libxtst-dev libxrandr-dev xdotool wmctrl xclip scrot
+
+git clone https://github.com/zavora-ai/computer-use-mcp
+cd computer-use-mcp
+npm install
+npm run build:native:linux  # builds Rust native module (.so -> .node)
+npm run build:ts            # compiles TypeScript
+```
+
+**Linux implementation details:**
+
+| What | How |
+|---|---|
+| Mouse & keyboard | X11/XTest — direct synthetic events via `XTestFakeKeyEvent`/`XTestFakeButtonEvent` |
+| Text input | `xdotool type` — reliable Unicode text entry |
+| App management | `wmctrl` + `xdotool` + `/proc` |
+| Window enumeration | `wmctrl -l -p` + `xdotool` |
+| Window activation | `xdotool windowactivate` |
+| Display info | X11 `XDisplayWidth`/`XDisplayHeight` |
+| Screenshots | `scrot` (fallback: `gnome-screenshot`, `import`) |
+| Clipboard | `xclip` (fallback: `xsel`) |
+| Workspaces | `wmctrl -d` for listing, `wmctrl -t` for moving windows |
+| Accessibility | Stubs (AT-SPI2 integration planned) |
+| Scripting | `bash` (or `pwsh` if installed) |
+
+**Notes:**
+- Currently supports X11 only. Wayland support is planned.
+- Accessibility features (UI tree, find_element, click_element) are stubbed — they return empty results rather than errors.
+- The `run_script` tool uses `bash` by default on Linux. Use `language: "bash"` in your scripts.
+
 ### Try the examples
 
 **Windows:**
@@ -933,9 +999,11 @@ This package has **full control of your computer** when permissions are granted.
 ## Limitations
 
 ### Platform
-- **macOS only.** The native module uses CoreGraphics, NSWorkspace, and `screencapture` — all macOS-specific. Linux and Windows are not supported.
-- **Minimum**: macOS 10.15 (Catalina) — required for `NSWorkspaceOpenConfiguration`.
-- **Tested on**: macOS 12 (Monterey), 13 (Ventura), 14 (Sonoma), 15 (Sequoia).
+- **macOS + Windows + Linux.** Each platform has a native Rust backend.
+- **macOS minimum**: macOS 10.15 (Catalina) — required for `NSWorkspaceOpenConfiguration`.
+- **macOS tested on**: macOS 12 (Monterey), 13 (Ventura), 14 (Sonoma), 15 (Sequoia).
+- **Linux**: X11 only (Wayland support planned). Requires `xdotool`, `wmctrl`, `xclip`, `scrot`.
+- **Linux tested on**: Ubuntu 24.04+ (GNOME on X11).
 
 ### Architecture
 - The prebuilt `.node` binary is compiled for the architecture of the machine it was built on (arm64 for Apple Silicon, x86_64 for Intel). If you're on a different architecture, build from source.
@@ -977,7 +1045,7 @@ This package has **full control of your computer** when permissions are granted.
 ## Troubleshooting
 
 ### "Error: computer-use-mcp requires macOS"
-You're running on Linux or Windows. This package is macOS-only.
+You're running on an unsupported platform. This package supports macOS, Windows, and Linux (X11).
 
 ### "Error: Cannot find module '...computer-use-napi.node'"
 The native binary is missing. Either:

--- a/examples/README.md
+++ b/examples/README.md
@@ -63,3 +63,28 @@ node examples/macos/open-vscode.mjs            # VS Code + TypeScript code
 node examples/macos/terminal-disk-space.mjs    # Disk space via Terminal
 node examples/macos/zoom.mjs                  # Region inspection at native resolution
 ```
+
+## Linux
+
+Linux examples work on both X11 and Wayland (GNOME, KDE, wlroots). The server auto-detects the session type.
+
+```bash
+# All cross-platform tools work on Linux:
+# screenshot, mouse, keyboard, clipboard, type, key, scroll, wait, display, workspaces
+
+# Example: open terminal, run commands, take screenshot
+node -e "
+import { createComputerUseServer } from '@zavora-ai/computer-use-mcp'
+import { connectInProcess } from '@zavora-ai/computer-use-mcp/client'
+const server = createComputerUseServer()
+const client = await connectInProcess(server)
+await client.callTool('key', { text: 'ctrl+alt+t' })  // open terminal
+await client.callTool('wait', { duration: 2 })
+await client.callTool('type', { text: 'uname -a' })
+await client.callTool('key', { text: 'return' })
+await client.screenshot({ width: 1024 })
+await client.close()
+"
+```
+
+**Requirements:** `xdotool`, `wmctrl`, `xclip`, `scrot` (X11) or `ydotool`, `wl-clipboard`, `grim` (Wayland).

--- a/native/Cargo.lock
+++ b/native/Cargo.lock
@@ -62,6 +62,7 @@ dependencies = [
  "core-graphics",
  "core-graphics-types",
  "image",
+ "libc",
  "napi",
  "napi-build",
  "napi-derive",
@@ -69,6 +70,7 @@ dependencies = [
  "serde",
  "serde_json",
  "windows",
+ "x11",
 ]
 
 [[package]]
@@ -339,6 +341,12 @@ name = "once_cell"
 version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
+
+[[package]]
+name = "pkg-config"
+version = "0.3.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
 
 [[package]]
 name = "png"
@@ -617,6 +625,16 @@ name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "x11"
+version = "2.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "502da5464ccd04011667b11c435cb992822c2c0dbde1770c988480d312a0db2e"
+dependencies = [
+ "libc",
+ "pkg-config",
+]
 
 [[package]]
 name = "zmij"

--- a/native/Cargo.toml
+++ b/native/Cargo.toml
@@ -26,6 +26,10 @@ core-graphics-types = "0.2"
 core-foundation = "0.10"
 objc = "0.2"
 
+[target.'cfg(target_os = "linux")'.dependencies]
+x11 = { version = "2.21", features = ["xlib", "xtest", "xrandr"] }
+libc = "0.2"
+
 [target.'cfg(target_os = "windows")'.dependencies]
 windows = { version = "0.58", features = [
     "Win32_UI_Input_KeyboardAndMouse",

--- a/native/build.rs
+++ b/native/build.rs
@@ -12,4 +12,12 @@ fn main() {
         println!("cargo:rustc-link-lib=framework=ApplicationServices");
         println!("cargo:rustc-link-lib=framework=ImageIO");
     }
+
+    // Link X11 libraries on Linux.
+    #[cfg(target_os = "linux")]
+    {
+        println!("cargo:rustc-link-lib=X11");
+        println!("cargo:rustc-link-lib=Xtst");
+        println!("cargo:rustc-link-lib=Xrandr");
+    }
 }

--- a/native/src/accessibility.rs
+++ b/native/src/accessibility.rs
@@ -1,3 +1,76 @@
+// ── Linux implementation — AT-SPI2 stub ──────────────────────────────────────
+#[cfg(target_os = "linux")]
+mod platform {
+    use napi_derive::napi;
+
+    // AT-SPI2 integration would go here. For now, provide stubs that return
+    // meaningful errors so the rest of the system works.
+
+    #[napi]
+    pub fn get_ui_tree(_window_id: u32, _max_depth: Option<u32>) -> napi::Result<serde_json::Value> {
+        Ok(serde_json::json!({
+            "role": "AXWindow",
+            "label": null,
+            "value": null,
+            "bounds": { "x": 0, "y": 0, "width": 0, "height": 0 },
+            "actions": [],
+            "children": [],
+            "truncated": true,
+        }))
+    }
+
+    #[napi]
+    pub fn get_focused_element() -> napi::Result<serde_json::Value> {
+        Ok(serde_json::json!(null))
+    }
+
+    #[napi]
+    pub fn find_element(
+        _window_id: u32,
+        _role: Option<String>,
+        _label: Option<String>,
+        _value: Option<String>,
+        _max_results: Option<u32>,
+    ) -> napi::Result<serde_json::Value> {
+        Ok(serde_json::json!([]))
+    }
+
+    #[napi]
+    pub fn perform_action(
+        _window_id: u32,
+        _role: String,
+        _label: String,
+        _action: String,
+    ) -> napi::Result<serde_json::Value> {
+        Err(napi::Error::from_reason("AT-SPI2 accessibility not yet implemented on Linux"))
+    }
+
+    #[napi]
+    pub fn set_element_value(
+        _window_id: u32,
+        _role: String,
+        _label: String,
+        _value: String,
+    ) -> napi::Result<serde_json::Value> {
+        Err(napi::Error::from_reason("AT-SPI2 accessibility not yet implemented on Linux"))
+    }
+
+    #[napi]
+    pub fn get_menu_bar(_bundle_id: String) -> napi::Result<serde_json::Value> {
+        Ok(serde_json::json!([]))
+    }
+
+    #[napi]
+    pub fn press_menu_item(
+        _bundle_id: String,
+        _menu: String,
+        _item: String,
+        _submenu: Option<String>,
+    ) -> napi::Result<serde_json::Value> {
+        Err(napi::Error::from_reason("Menu bar access not yet implemented on Linux"))
+    }
+}
+
 // ── macOS implementation ──────────────────────────────────────────────────────
 #[cfg(target_os = "macos")]
 #[path = "accessibility_macos.rs"]

--- a/native/src/apps.rs
+++ b/native/src/apps.rs
@@ -1,3 +1,143 @@
+// ── Linux implementation ──────────────────────────────────────────────────────
+#[cfg(target_os = "linux")]
+mod linux {
+    use napi_derive::napi;
+    use std::process::Command;
+    use std::sync::OnceLock;
+
+    static IS_WAYLAND: OnceLock<bool> = OnceLock::new();
+
+    fn is_wayland() -> bool {
+        *IS_WAYLAND.get_or_init(|| {
+            std::env::var("XDG_SESSION_TYPE").map(|v| v == "wayland").unwrap_or(false)
+        })
+    }
+
+    fn gdbus_eval(js: &str) -> Option<String> {
+        let output = Command::new("gdbus").args([
+            "call", "--session",
+            "--dest", "org.gnome.Shell",
+            "--object-path", "/org/gnome/Shell",
+            "--method", "org.gnome.Shell.Eval",
+            js,
+        ]).output().ok()?;
+        let text = String::from_utf8_lossy(&output.stdout).to_string();
+        if text.starts_with("(true,") {
+            let start = text.find('\'')?;
+            let end = text.rfind('\'')?;
+            if start < end {
+                return Some(text[start+1..end].replace("\\'", "'"));
+            }
+        }
+        None
+    }
+
+    #[napi(js_name = "drainRunloop")]
+    pub fn drain_runloop_pub() {}
+
+    #[napi]
+    pub fn get_frontmost_app() -> napi::Result<serde_json::Value> {
+        if is_wayland() {
+            let js = r#"let w=global.get_window_actors().map(a=>a.meta_window).find(w=>w.has_focus());w?JSON.stringify({bundleId:w.get_wm_class()||'',displayName:w.get_title()||'',pid:w.get_pid()}):'null'"#;
+            if let Some(json_str) = gdbus_eval(js) {
+                if json_str != "null" {
+                    if let Ok(val) = serde_json::from_str::<serde_json::Value>(&json_str) {
+                        return Ok(val);
+                    }
+                }
+            }
+        }
+        // X11/fallback
+        let output = Command::new("xdotool").args(["getactivewindow", "getwindowpid"]).output();
+        let pid = output.ok()
+            .and_then(|o| String::from_utf8_lossy(&o.stdout).trim().parse::<i32>().ok())
+            .unwrap_or(0);
+        let name_output = Command::new("xdotool").args(["getactivewindow", "getwindowname"]).output();
+        let title = name_output.ok()
+            .map(|o| String::from_utf8_lossy(&o.stdout).trim().to_string())
+            .unwrap_or_default();
+        let proc_name = std::fs::read_to_string(format!("/proc/{pid}/comm"))
+            .unwrap_or_default().trim().to_string();
+        Ok(serde_json::json!({ "bundleId": proc_name, "displayName": title, "pid": pid }))
+    }
+
+    #[napi]
+    pub fn activate_app(bundle_id: String, _timeout_ms: Option<i32>) -> napi::Result<serde_json::Value> {
+        if is_wayland() {
+            let js = format!(
+                r#"let w=global.get_window_actors().map(a=>a.meta_window).find(w=>(w.get_wm_class()||'').toLowerCase()==='{cls}'.toLowerCase());if(w){{w.activate(global.get_current_time());'true'}}else{{'false'}}"#,
+                cls = bundle_id.replace('\'', "\\'")
+            );
+            let activated = gdbus_eval(&js).map(|s| s == "true").unwrap_or(false);
+            if activated {
+                return Ok(serde_json::json!({ "bundleId": bundle_id, "activated": true, "displayName": bundle_id }));
+            }
+        }
+        // Try wmctrl
+        let status = Command::new("wmctrl").args(["-x", "-a", &bundle_id]).status();
+        let activated = status.map(|s| s.success()).unwrap_or(false);
+        Ok(serde_json::json!({ "bundleId": bundle_id, "activated": activated, "displayName": bundle_id }))
+    }
+
+    #[napi]
+    pub fn list_running_apps() -> napi::Result<serde_json::Value> {
+        if is_wayland() {
+            let js = r#"JSON.stringify([...new Set(global.get_window_actors().map(a=>{let w=a.meta_window;return JSON.stringify({bundleId:w.get_wm_class()||'',displayName:w.get_wm_class()||'',pid:w.get_pid(),isHidden:w.minimized})}))].map(s=>JSON.parse(s)))"#;
+            if let Some(json_str) = gdbus_eval(js) {
+                if let Ok(val) = serde_json::from_str::<serde_json::Value>(&json_str) {
+                    return Ok(val);
+                }
+            }
+        }
+        // X11 fallback: list unique processes with windows
+        let output = Command::new("wmctrl").args(["-l", "-p"]).output().unwrap_or_else(|_| {
+            Command::new("true").output().unwrap()
+        });
+        let text = String::from_utf8_lossy(&output.stdout);
+        let mut seen = std::collections::HashMap::new();
+        for line in text.lines() {
+            let parts: Vec<&str> = line.splitn(5, char::is_whitespace).filter(|s| !s.is_empty()).collect();
+            if parts.len() >= 3 {
+                let pid = parts[2].parse::<i32>().unwrap_or(0);
+                let proc_name = std::fs::read_to_string(format!("/proc/{pid}/comm"))
+                    .unwrap_or_default().trim().to_string();
+                if !proc_name.is_empty() && !seen.contains_key(&proc_name) {
+                    seen.insert(proc_name.clone(), serde_json::json!({
+                        "bundleId": proc_name, "displayName": proc_name, "pid": pid, "isHidden": false,
+                    }));
+                }
+            }
+        }
+        Ok(serde_json::json!(seen.into_values().collect::<Vec<_>>()))
+    }
+
+    #[napi]
+    pub fn hide_app(bundle_id: String) -> bool {
+        if is_wayland() {
+            let js = format!(
+                r#"global.get_window_actors().map(a=>a.meta_window).filter(w=>(w.get_wm_class()||'').toLowerCase()==='{cls}'.toLowerCase()).forEach(w=>w.minimize());'ok'"#,
+                cls = bundle_id.replace('\'', "\\'")
+            );
+            return gdbus_eval(&js).is_some();
+        }
+        let _ = Command::new("xdotool").args(["search", "--class", &bundle_id, "windowminimize"]).status();
+        true
+    }
+
+    #[napi]
+    pub fn unhide_app(bundle_id: String) -> bool {
+        if is_wayland() {
+            let js = format!(
+                r#"let w=global.get_window_actors().map(a=>a.meta_window).find(w=>(w.get_wm_class()||'').toLowerCase()==='{cls}'.toLowerCase());if(w){{w.unminimize();w.activate(global.get_current_time());'true'}}else{{'false'}}"#,
+                cls = bundle_id.replace('\'', "\\'")
+            );
+            return gdbus_eval(&js).map(|s| s == "true").unwrap_or(false);
+        }
+        let status = Command::new("wmctrl").args(["-x", "-a", &bundle_id]).status();
+        status.map(|s| s.success()).unwrap_or(false)
+    }
+}
+
 // ── macOS implementation ──────────────────────────────────────────────────────
 #[cfg(target_os = "macos")]
 mod macos {

--- a/native/src/clipboard.rs
+++ b/native/src/clipboard.rs
@@ -1,6 +1,58 @@
 // ── macOS: clipboard handled in session layer via pbcopy/pbpaste ─────────────
 // No native clipboard functions needed on macOS.
 
+// ── Linux implementation ─────────────────────────────────────────────────────
+#[cfg(target_os = "linux")]
+mod linux {
+    use napi_derive::napi;
+    use std::process::Command;
+    use std::sync::OnceLock;
+
+    static IS_WAYLAND: OnceLock<bool> = OnceLock::new();
+
+    fn is_wayland() -> bool {
+        *IS_WAYLAND.get_or_init(|| {
+            std::env::var("XDG_SESSION_TYPE").map(|v| v == "wayland").unwrap_or(false)
+        })
+    }
+
+    #[napi]
+    pub fn read_clipboard() -> napi::Result<String> {
+        let output = if is_wayland() {
+            Command::new("wl-paste").args(["--no-newline"]).output()
+                .or_else(|_| Command::new("xclip").args(["-selection", "clipboard", "-o"]).output())
+        } else {
+            Command::new("xclip").args(["-selection", "clipboard", "-o"]).output()
+                .or_else(|_| Command::new("xsel").args(["--clipboard", "--output"]).output())
+        };
+        let output = output.map_err(|e| napi::Error::from_reason(
+            format!("clipboard read failed (install wl-clipboard or xclip): {e}")))?;
+        Ok(String::from_utf8_lossy(&output.stdout).into_owned())
+    }
+
+    #[napi]
+    pub fn write_clipboard(text: String) -> napi::Result<()> {
+        if is_wayland() {
+            // wl-copy works best with text as argument
+            let status = Command::new("wl-copy").arg(&text).status()
+                .map_err(|e| napi::Error::from_reason(format!("wl-copy failed: {e}")))?;
+            if status.success() { return Ok(()); }
+        }
+        // X11 fallback: pipe to xclip
+        use std::io::Write;
+        let child = Command::new("xclip").args(["-selection", "clipboard"])
+            .stdin(std::process::Stdio::piped()).spawn()
+            .or_else(|_| Command::new("xsel").args(["--clipboard", "--input"]).stdin(std::process::Stdio::piped()).spawn());
+        let mut child = child.map_err(|e| napi::Error::from_reason(
+            format!("clipboard write failed (install wl-clipboard or xclip): {e}")))?;
+        if let Some(mut stdin) = child.stdin.take() {
+            stdin.write_all(text.as_bytes()).map_err(|e| napi::Error::from_reason(format!("write: {e}")))?;
+        }
+        child.wait().map_err(|e| napi::Error::from_reason(format!("wait: {e}")))?;
+        Ok(())
+    }
+}
+
 // ── Windows implementation ───────────────────────────────────────────────────
 #[cfg(target_os = "windows")]
 mod win {

--- a/native/src/display.rs
+++ b/native/src/display.rs
@@ -1,3 +1,52 @@
+// ── Linux implementation ──────────────────────────────────────────────────────
+#[cfg(target_os = "linux")]
+mod linux {
+    use napi_derive::napi;
+    use x11::xlib::*;
+    use std::ptr;
+
+    #[napi]
+    pub fn get_display_size(display_id: Option<u32>) -> napi::Result<serde_json::Value> {
+        unsafe {
+            let dpy = XOpenDisplay(ptr::null());
+            if dpy.is_null() { return Err(napi::Error::from_reason("Cannot open X display")); }
+            let screen = display_id.unwrap_or(0) as i32;
+            let screen = if screen < XScreenCount(dpy) { screen } else { XDefaultScreen(dpy) };
+            let w = XDisplayWidth(dpy, screen) as u64;
+            let h = XDisplayHeight(dpy, screen) as u64;
+            XCloseDisplay(dpy);
+            Ok(serde_json::json!({
+                "width": w, "height": h,
+                "pixelWidth": w, "pixelHeight": h,
+                "scaleFactor": 1.0,
+                "displayId": screen,
+            }))
+        }
+    }
+
+    #[napi]
+    pub fn list_displays() -> napi::Result<serde_json::Value> {
+        unsafe {
+            let dpy = XOpenDisplay(ptr::null());
+            if dpy.is_null() { return Err(napi::Error::from_reason("Cannot open X display")); }
+            let count = XScreenCount(dpy);
+            let mut result = Vec::new();
+            for i in 0..count {
+                let w = XDisplayWidth(dpy, i) as u64;
+                let h = XDisplayHeight(dpy, i) as u64;
+                result.push(serde_json::json!({
+                    "width": w, "height": h,
+                    "pixelWidth": w, "pixelHeight": h,
+                    "scaleFactor": 1.0,
+                    "displayId": i,
+                }));
+            }
+            XCloseDisplay(dpy);
+            Ok(serde_json::json!(result))
+        }
+    }
+}
+
 // ── macOS implementation ──────────────────────────────────────────────────────
 #[cfg(target_os = "macos")]
 mod macos {

--- a/native/src/keyboard.rs
+++ b/native/src/keyboard.rs
@@ -1,3 +1,208 @@
+// ── Linux implementation ──────────────────────────────────────────────────────
+#[cfg(target_os = "linux")]
+mod linux {
+    use napi_derive::napi;
+    use std::collections::HashMap;
+    use std::process::Command;
+    use std::sync::OnceLock;
+
+    static IS_WAYLAND: OnceLock<bool> = OnceLock::new();
+
+    fn is_wayland() -> bool {
+        *IS_WAYLAND.get_or_init(|| {
+            std::env::var("XDG_SESSION_TYPE").map(|v| v == "wayland").unwrap_or(false)
+        })
+    }
+
+    static LINUX_KEY_MAP: OnceLock<HashMap<&'static str, u32>> = OnceLock::new();
+
+    fn key_map() -> &'static HashMap<&'static str, u32> {
+        LINUX_KEY_MAP.get_or_init(|| {
+            let mut m = HashMap::new();
+            m.insert("return", 36); m.insert("enter", 36);
+            m.insert("tab", 23); m.insert("space", 65);
+            m.insert("backspace", 22); m.insert("delete", 119);
+            m.insert("escape", 9); m.insert("esc", 9);
+            m.insert("shift", 50); m.insert("control", 37); m.insert("ctrl", 37);
+            m.insert("alt", 64); m.insert("option", 64);
+            m.insert("super", 133); m.insert("command", 133); m.insert("cmd", 133);
+            m.insert("win", 133); m.insert("capslock", 66);
+            m.insert("f1", 67); m.insert("f2", 68); m.insert("f3", 69);
+            m.insert("f4", 70); m.insert("f5", 71); m.insert("f6", 72);
+            m.insert("f7", 73); m.insert("f8", 74); m.insert("f9", 75);
+            m.insert("f10", 76); m.insert("f11", 95); m.insert("f12", 96);
+            m.insert("home", 110); m.insert("end", 115);
+            m.insert("pageup", 112); m.insert("pagedown", 117);
+            m.insert("left", 113); m.insert("right", 114);
+            m.insert("up", 111); m.insert("down", 116);
+            m.insert("a", 38); m.insert("b", 56); m.insert("c", 54);
+            m.insert("d", 40); m.insert("e", 26); m.insert("f", 41);
+            m.insert("g", 42); m.insert("h", 43); m.insert("i", 31);
+            m.insert("j", 44); m.insert("k", 45); m.insert("l", 46);
+            m.insert("m", 58); m.insert("n", 57); m.insert("o", 32);
+            m.insert("p", 33); m.insert("q", 24); m.insert("r", 27);
+            m.insert("s", 39); m.insert("t", 28); m.insert("u", 30);
+            m.insert("v", 55); m.insert("w", 25); m.insert("x", 53);
+            m.insert("y", 29); m.insert("z", 52);
+            m.insert("0", 19); m.insert("1", 10); m.insert("2", 11);
+            m.insert("3", 12); m.insert("4", 13); m.insert("5", 14);
+            m.insert("6", 15); m.insert("7", 16); m.insert("8", 17);
+            m.insert("9", 18);
+            m.insert("-", 20); m.insert("=", 21);
+            m.insert("[", 34); m.insert("]", 35);
+            m.insert("\\", 51); m.insert(";", 47);
+            m.insert("'", 48); m.insert(",", 59);
+            m.insert(".", 60); m.insert("/", 61);
+            m.insert("`", 49);
+            m
+        })
+    }
+
+    fn is_modifier(keycode: u32) -> bool {
+        matches!(keycode, 50 | 37 | 64 | 133 | 66)
+    }
+
+    // ydotool uses evdev keycodes (X11 keycode - 8)
+    fn x11_to_evdev(x11_keycode: u32) -> u32 {
+        x11_keycode.saturating_sub(8)
+    }
+
+    fn ydotool_key_combo(combo: &str, repeat: i32) -> napi::Result<()> {
+        let map = key_map();
+        let combo_lower = combo.to_lowercase();
+        let parts: Vec<&str> = combo_lower.split('+').map(|s| s.trim()).collect();
+
+        let mut codes: Vec<u32> = Vec::new();
+        for part in &parts {
+            let kc = map.get(part).copied()
+                .ok_or_else(|| napi::Error::from_reason(format!("Unknown key in combo: {combo}")))?;
+            codes.push(x11_to_evdev(kc));
+        }
+
+        // Build ydotool key sequence: "keydown code keydown code ... keyup code keyup code"
+        for _ in 0..repeat {
+            let mut args: Vec<String> = vec!["key".to_string()];
+            for &c in &codes {
+                args.push(format!("{}:1", c)); // key down
+            }
+            for c in codes.iter().rev() {
+                args.push(format!("{}:0", c)); // key up
+            }
+            let _ = Command::new("ydotool").args(&args).status();
+        }
+        Ok(())
+    }
+
+    #[napi]
+    pub fn key_press(combo: String, repeat: Option<i32>) -> napi::Result<()> {
+        let repeat = repeat.unwrap_or(1);
+
+        if is_wayland() {
+            return ydotool_key_combo(&combo, repeat);
+        }
+
+        // X11 path
+        let map = key_map();
+        let combo_lower = combo.to_lowercase();
+        let parts: Vec<&str> = combo_lower.split('+').map(|s| s.trim()).collect();
+
+        let mut modifiers: Vec<u32> = Vec::new();
+        let mut main_key: Option<u32> = None;
+
+        for part in &parts {
+            if let Some(&kc) = map.get(part) {
+                if is_modifier(kc) {
+                    modifiers.push(kc);
+                } else {
+                    main_key = Some(kc);
+                }
+            }
+        }
+
+        let key = main_key.ok_or_else(|| napi::Error::from_reason(format!("Unknown key in combo: {combo}")))?;
+
+        unsafe {
+            use x11::xlib::*;
+            use x11::xtest::*;
+            let dpy = XOpenDisplay(std::ptr::null());
+            if dpy.is_null() { return Err(napi::Error::from_reason("Cannot open X display")); }
+
+            for i in 0..repeat {
+                for &m in &modifiers {
+                    XTestFakeKeyEvent(dpy, m, 1, 0);
+                }
+                XTestFakeKeyEvent(dpy, key, 1, 0);
+                XTestFakeKeyEvent(dpy, key, 0, 0);
+                for m in modifiers.iter().rev() {
+                    XTestFakeKeyEvent(dpy, *m, 0, 0);
+                }
+                XFlush(dpy);
+                if i < repeat - 1 {
+                    std::thread::sleep(std::time::Duration::from_millis(5));
+                }
+            }
+            XCloseDisplay(dpy);
+        }
+        Ok(())
+    }
+
+    #[napi]
+    pub fn type_text(text: String) {
+        if is_wayland() {
+            let _ = Command::new("ydotool").args(["type", "--", &text]).status();
+        } else {
+            let _ = Command::new("xdotool").args(["type", "--clearmodifiers", &text]).status();
+        }
+    }
+
+    #[napi]
+    pub fn hold_key(keys: Vec<String>, duration_ms: i32) -> napi::Result<()> {
+        let map = key_map();
+
+        if is_wayland() {
+            let mut down_args: Vec<String> = vec!["key".to_string()];
+            let mut up_args: Vec<String> = vec!["key".to_string()];
+            for k in &keys {
+                let lower = k.to_lowercase();
+                let kc = map.get(lower.as_str()).copied()
+                    .ok_or_else(|| napi::Error::from_reason(format!("Unknown key: {k}")))?;
+                let evdev = x11_to_evdev(kc);
+                down_args.push(format!("{}:1", evdev));
+                up_args.push(format!("{}:0", evdev));
+            }
+            let _ = Command::new("ydotool").args(&down_args).status();
+            std::thread::sleep(std::time::Duration::from_millis(duration_ms as u64));
+            let _ = Command::new("ydotool").args(&up_args).status();
+            return Ok(());
+        }
+
+        // X11 path
+        unsafe {
+            use x11::xlib::*;
+            use x11::xtest::*;
+            let dpy = XOpenDisplay(std::ptr::null());
+            if dpy.is_null() { return Err(napi::Error::from_reason("Cannot open X display")); }
+
+            let mut pressed: Vec<u32> = Vec::new();
+            for k in &keys {
+                let lower = k.to_lowercase();
+                let kc = map.get(lower.as_str()).copied()
+                    .ok_or_else(|| napi::Error::from_reason(format!("Unknown key: {k}")))?;
+                XTestFakeKeyEvent(dpy, kc, 1, 0);
+                pressed.push(kc);
+            }
+            XFlush(dpy);
+            std::thread::sleep(std::time::Duration::from_millis(duration_ms as u64));
+            for kc in pressed.into_iter().rev() {
+                XTestFakeKeyEvent(dpy, kc, 0, 0);
+            }
+            XFlush(dpy);
+            XCloseDisplay(dpy);
+        }
+        Ok(())
+    }
+}
+
 // ── macOS implementation ──────────────────────────────────────────────────────
 #[cfg(target_os = "macos")]
 mod macos {

--- a/native/src/lib.rs
+++ b/native/src/lib.rs
@@ -1,6 +1,6 @@
 mod accessibility;
 mod apps;
-#[cfg(target_os = "windows")]
+#[cfg(any(target_os = "windows", target_os = "linux"))]
 mod clipboard;
 mod display;
 mod keyboard;

--- a/native/src/mouse.rs
+++ b/native/src/mouse.rs
@@ -1,3 +1,235 @@
+// ── Linux implementation ──────────────────────────────────────────────────────
+#[cfg(target_os = "linux")]
+mod linux {
+    use napi_derive::napi;
+    use std::process::Command;
+    use std::sync::OnceLock;
+
+    static IS_WAYLAND: OnceLock<bool> = OnceLock::new();
+
+    fn is_wayland() -> bool {
+        *IS_WAYLAND.get_or_init(|| {
+            std::env::var("XDG_SESSION_TYPE").map(|v| v == "wayland").unwrap_or(false)
+        })
+    }
+
+    fn ydotool_available() -> bool {
+        Command::new("ydotool").arg("--help").output().is_ok()
+    }
+
+    mod x11_impl {
+        use x11::xlib::*;
+        use x11::xtest::*;
+        use std::ptr;
+
+        pub unsafe fn open_display() -> *mut Display {
+            XOpenDisplay(ptr::null())
+        }
+
+        pub fn mouse_move(x: i32, y: i32) {
+            unsafe {
+                let dpy = open_display();
+                if dpy.is_null() { return; }
+                XWarpPointer(dpy, 0, XDefaultRootWindow(dpy), 0, 0, 0, 0, x, y);
+                XFlush(dpy);
+                XCloseDisplay(dpy);
+            }
+        }
+
+        pub fn mouse_click(x: i32, y: i32, btn: u32, count: i32) {
+            unsafe {
+                let dpy = open_display();
+                if dpy.is_null() { return; }
+                XWarpPointer(dpy, 0, XDefaultRootWindow(dpy), 0, 0, 0, 0, x, y);
+                XFlush(dpy);
+                std::thread::sleep(std::time::Duration::from_millis(10));
+                for i in 0..count {
+                    XTestFakeButtonEvent(dpy, btn, 1, 0);
+                    XTestFakeButtonEvent(dpy, btn, 0, 0);
+                    if i < count - 1 {
+                        XFlush(dpy);
+                        std::thread::sleep(std::time::Duration::from_millis(30));
+                    }
+                }
+                XFlush(dpy);
+                XCloseDisplay(dpy);
+            }
+        }
+
+        pub fn mouse_button(press: bool, x: i32, y: i32) {
+            unsafe {
+                let dpy = open_display();
+                if dpy.is_null() { return; }
+                XWarpPointer(dpy, 0, XDefaultRootWindow(dpy), 0, 0, 0, 0, x, y);
+                XTestFakeButtonEvent(dpy, 1, if press { 1 } else { 0 }, 0);
+                XFlush(dpy);
+                XCloseDisplay(dpy);
+            }
+        }
+
+        pub fn mouse_scroll(dy: i32, dx: i32) {
+            unsafe {
+                let dpy = open_display();
+                if dpy.is_null() { return; }
+                if dy != 0 {
+                    let btn = if dy > 0 { 5u32 } else { 4 };
+                    for _ in 0..dy.unsigned_abs() {
+                        XTestFakeButtonEvent(dpy, btn, 1, 0);
+                        XTestFakeButtonEvent(dpy, btn, 0, 0);
+                    }
+                }
+                if dx != 0 {
+                    let btn = if dx > 0 { 7u32 } else { 6 };
+                    for _ in 0..dx.unsigned_abs() {
+                        XTestFakeButtonEvent(dpy, btn, 1, 0);
+                        XTestFakeButtonEvent(dpy, btn, 0, 0);
+                    }
+                }
+                XFlush(dpy);
+                XCloseDisplay(dpy);
+            }
+        }
+
+        pub fn cursor_position() -> (i32, i32) {
+            unsafe {
+                let dpy = open_display();
+                if dpy.is_null() { return (0, 0); }
+                let root = XDefaultRootWindow(dpy);
+                let mut root_ret = 0u64;
+                let mut child_ret = 0u64;
+                let mut rx = 0i32;
+                let mut ry = 0i32;
+                let mut wx = 0i32;
+                let mut wy = 0i32;
+                let mut mask = 0u32;
+                XQueryPointer(dpy, root, &mut root_ret, &mut child_ret, &mut rx, &mut ry, &mut wx, &mut wy, &mut mask);
+                XCloseDisplay(dpy);
+                (rx, ry)
+            }
+        }
+    }
+
+    mod wayland_impl {
+        use std::process::Command;
+
+        pub fn mouse_move(x: i32, y: i32) {
+            let _ = Command::new("ydotool").args(["mousemove", "--absolute", "-x", &x.to_string(), "-y", &y.to_string()]).status();
+        }
+
+        pub fn mouse_click(x: i32, y: i32, btn: u32, count: i32) {
+            // Move first
+            mouse_move(x, y);
+            std::thread::sleep(std::time::Duration::from_millis(10));
+            // ydotool button codes: 0x00=left, 0x01=right, 0x02=middle
+            let ydotool_btn = match btn {
+                1 => "0x00",
+                2 => "0x02",
+                3 => "0x01",
+                _ => "0x00",
+            };
+            for i in 0..count {
+                let _ = Command::new("ydotool").args(["click", ydotool_btn]).status();
+                if i < count - 1 {
+                    std::thread::sleep(std::time::Duration::from_millis(30));
+                }
+            }
+        }
+
+        pub fn mouse_button(press: bool, x: i32, y: i32) {
+            mouse_move(x, y);
+            // ydotool click with --down or --up
+            if press {
+                let _ = Command::new("ydotool").args(["click", "--down", "0x00"]).status();
+            } else {
+                let _ = Command::new("ydotool").args(["click", "--up", "0x00"]).status();
+            }
+        }
+
+        pub fn mouse_scroll(dy: i32, dx: i32) {
+            if dy != 0 {
+                // Negative = scroll up in ydotool
+                let _ = Command::new("ydotool").args(["mousemove", "--wheel", "--", "-x", "0", "-y", &(-dy * 15).to_string()]).status();
+            }
+            if dx != 0 {
+                let _ = Command::new("ydotool").args(["mousemove", "--wheel", "--", "-x", &(dx * 15).to_string(), "-y", "0"]).status();
+            }
+        }
+
+        pub fn cursor_position() -> (i32, i32) {
+            // Wayland doesn't expose cursor position easily; fall back to X11 via XWayland
+            super::x11_impl::cursor_position()
+        }
+    }
+
+    #[napi]
+    pub fn mouse_move(x: f64, y: f64) {
+        if is_wayland() && ydotool_available() {
+            wayland_impl::mouse_move(x as i32, y as i32);
+        } else {
+            x11_impl::mouse_move(x as i32, y as i32);
+        }
+    }
+
+    #[napi]
+    pub fn mouse_click(x: f64, y: f64, button: String, count: i32) -> napi::Result<()> {
+        let btn = match button.as_str() {
+            "left" => 1u32,
+            "middle" => 2,
+            "right" => 3,
+            _ => return Err(napi::Error::from_reason(format!("Invalid button: {button}"))),
+        };
+        if is_wayland() && ydotool_available() {
+            wayland_impl::mouse_click(x as i32, y as i32, btn, count);
+        } else {
+            x11_impl::mouse_click(x as i32, y as i32, btn, count);
+        }
+        Ok(())
+    }
+
+    #[napi]
+    pub fn mouse_button(action: String, x: f64, y: f64) -> napi::Result<()> {
+        let press = match action.as_str() {
+            "press" => true,
+            "release" => false,
+            _ => return Err(napi::Error::from_reason(format!("Invalid action: {action}"))),
+        };
+        if is_wayland() && ydotool_available() {
+            wayland_impl::mouse_button(press, x as i32, y as i32);
+        } else {
+            x11_impl::mouse_button(press, x as i32, y as i32);
+        }
+        Ok(())
+    }
+
+    #[napi]
+    pub fn mouse_scroll(dy: i32, dx: i32) {
+        if is_wayland() && ydotool_available() {
+            wayland_impl::mouse_scroll(dy, dx);
+        } else {
+            x11_impl::mouse_scroll(dy, dx);
+        }
+    }
+
+    #[napi]
+    pub fn mouse_drag(x: f64, y: f64) {
+        if is_wayland() && ydotool_available() {
+            wayland_impl::mouse_move(x as i32, y as i32);
+        } else {
+            x11_impl::mouse_move(x as i32, y as i32);
+        }
+    }
+
+    #[napi]
+    pub fn cursor_position() -> napi::Result<serde_json::Value> {
+        let (rx, ry) = if is_wayland() && ydotool_available() {
+            wayland_impl::cursor_position()
+        } else {
+            x11_impl::cursor_position()
+        };
+        Ok(serde_json::json!({"x": rx, "y": ry}))
+    }
+}
+
 // ── macOS implementation ──────────────────────────────────────────────────────
 #[cfg(target_os = "macos")]
 mod macos {

--- a/native/src/screenshot.rs
+++ b/native/src/screenshot.rs
@@ -1,3 +1,157 @@
+// ── Linux implementation ──────────────────────────────────────────────────────
+#[cfg(target_os = "linux")]
+mod linux {
+    use base64::Engine;
+    use napi_derive::napi;
+    use std::collections::hash_map::DefaultHasher;
+    use std::hash::{Hash, Hasher};
+    use std::process::Command;
+    use std::sync::atomic::{AtomicU32, Ordering};
+    use std::sync::OnceLock;
+
+    static SHOT_SEQ: AtomicU32 = AtomicU32::new(0);
+    static IS_WAYLAND: OnceLock<bool> = OnceLock::new();
+
+    fn is_wayland() -> bool {
+        *IS_WAYLAND.get_or_init(|| {
+            std::env::var("XDG_SESSION_TYPE").map(|v| v == "wayland").unwrap_or(false)
+        })
+    }
+
+    fn capture_wayland(tmp_path: &str, _window_id: Option<u32>) -> bool {
+        // Try gnome-screenshot first (works on some GNOME Wayland versions)
+        if Command::new("gnome-screenshot").args(["-f", tmp_path]).status()
+            .map(|s| s.success()).unwrap_or(false) {
+            if std::path::Path::new(tmp_path).exists() { return true; }
+        }
+        // Try grim (works on wlroots compositors)
+        if Command::new("grim").arg(tmp_path).status()
+            .map(|s| s.success()).unwrap_or(false) {
+            if std::path::Path::new(tmp_path).exists() { return true; }
+        }
+        // Use XDG Desktop Portal (works on GNOME 50+ Wayland)
+        let portal_result = Command::new("gdbus").args([
+            "call", "--session",
+            "--dest", "org.freedesktop.portal.Desktop",
+            "--object-path", "/org/freedesktop/portal/desktop",
+            "--method", "org.freedesktop.portal.Screenshot.Screenshot",
+            "", "{'interactive': <false>}",
+        ]).output();
+        if portal_result.is_ok() {
+            // Portal saves to ~/Pictures/Screenshot*.png — wait and find it
+            std::thread::sleep(std::time::Duration::from_millis(1500));
+            let pictures_dir = std::env::var("HOME").unwrap_or_default() + "/Pictures";
+            if let Ok(entries) = std::fs::read_dir(&pictures_dir) {
+                let mut screenshots: Vec<_> = entries.filter_map(|e| e.ok())
+                    .filter(|e| e.file_name().to_string_lossy().starts_with("Screenshot"))
+                    .collect();
+                screenshots.sort_by_key(|e| std::cmp::Reverse(e.metadata().ok().and_then(|m| m.modified().ok())));
+                if let Some(latest) = screenshots.first() {
+                    if let Ok(_) = std::fs::copy(latest.path(), tmp_path) {
+                        let _ = std::fs::remove_file(latest.path());
+                        return true;
+                    }
+                }
+            }
+        }
+        // Fall back to scrot via XWayland
+        Command::new("scrot").arg(tmp_path).status()
+            .map(|s| s.success()).unwrap_or(false)
+    }
+
+    fn capture_x11(tmp_path: &str, window_id: Option<u32>, target_app: &Option<String>) -> bool {
+        if let Some(wid) = window_id {
+            if Command::new("import").args(["-window", &wid.to_string(), tmp_path]).status()
+                .map(|s| s.success()).unwrap_or(false) { return true; }
+        }
+        if target_app.is_some() {
+            if Command::new("scrot").args(["-u", tmp_path]).status()
+                .map(|s| s.success()).unwrap_or(false) { return true; }
+        }
+        Command::new("scrot").arg(tmp_path).status()
+            .map(|s| s.success()).unwrap_or(false)
+            || Command::new("gnome-screenshot").args(["-f", tmp_path]).status()
+                .map(|s| s.success()).unwrap_or(false)
+            || Command::new("import").args(["-window", "root", tmp_path]).status()
+                .map(|s| s.success()).unwrap_or(false)
+    }
+
+    #[napi]
+    pub fn take_screenshot(
+        width: Option<u32>,
+        target_app: Option<String>,
+        quality: Option<u32>,
+        previous_hash: Option<String>,
+        window_id: Option<u32>,
+    ) -> napi::Result<serde_json::Value> {
+        let seq = SHOT_SEQ.fetch_add(1, Ordering::Relaxed);
+        let tmp_path = format!("/tmp/cu-mcp-shot-{}-{}.png", std::process::id(), seq);
+
+        let captured = if is_wayland() {
+            capture_wayland(&tmp_path, window_id)
+        } else {
+            capture_x11(&tmp_path, window_id, &target_app)
+        };
+
+        if !captured || !std::path::Path::new(&tmp_path).exists() {
+            return Err(napi::Error::from_reason(
+                "Screenshot failed: install scrot, gnome-screenshot, or grim"));
+        }
+
+        let raw = std::fs::read(&tmp_path).map_err(|e| napi::Error::from_reason(format!("read: {e}")))?;
+        let _ = std::fs::remove_file(&tmp_path);
+
+        let img = image::load_from_memory(&raw)
+            .map_err(|e| napi::Error::from_reason(format!("decode: {e}")))?;
+
+        let target_width = width.unwrap_or(1024);
+        let resized = if img.width() > target_width {
+            img.resize(target_width, u32::MAX, image::imageops::FilterType::Lanczos3)
+        } else {
+            img
+        };
+
+        let q = quality.unwrap_or(80);
+        let (encoded, mime) = if q == 0 {
+            let mut buf = Vec::new();
+            resized.write_to(&mut std::io::Cursor::new(&mut buf), image::ImageFormat::Png)
+                .map_err(|e| napi::Error::from_reason(format!("png encode: {e}")))?;
+            (buf, "image/png")
+        } else {
+            let mut buf = Vec::new();
+            resized.write_to(&mut std::io::Cursor::new(&mut buf), image::ImageFormat::Jpeg)
+                .map_err(|e| napi::Error::from_reason(format!("jpeg encode: {e}")))?;
+            (buf, "image/jpeg")
+        };
+
+        let mut hasher = DefaultHasher::new();
+        encoded.hash(&mut hasher);
+        let hash = format!("{:x}", hasher.finish());
+
+        if let Some(prev) = previous_hash {
+            if prev == hash {
+                return Ok(serde_json::json!({
+                    "width": resized.width(),
+                    "height": resized.height(),
+                    "mimeType": mime,
+                    "hash": hash,
+                    "unchanged": true,
+                }));
+            }
+        }
+
+        let b64 = base64::engine::general_purpose::STANDARD.encode(&encoded);
+        Ok(serde_json::json!({
+            "base64": b64,
+            "width": resized.width(),
+            "height": resized.height(),
+            "mimeType": mime,
+            "hash": hash,
+            "unchanged": false,
+        }))
+    }
+}
+
 // ── macOS implementation ──────────────────────────────────────────────────────
 #[cfg(target_os = "macos")]
 mod macos {

--- a/native/src/spaces.rs
+++ b/native/src/spaces.rs
@@ -1,3 +1,74 @@
+// ── Linux implementation — workspaces stub ───────────────────────────────────
+#[cfg(target_os = "linux")]
+mod platform {
+    use napi_derive::napi;
+
+    #[napi]
+    pub fn list_spaces() -> napi::Result<serde_json::Value> {
+        // Try wmctrl -d to list desktops
+        let output = std::process::Command::new("wmctrl").args(["-d"]).output();
+        if let Ok(out) = output {
+            let text = String::from_utf8_lossy(&out.stdout);
+            let mut spaces = Vec::new();
+            let mut active_id = None;
+            for line in text.lines() {
+                let parts: Vec<&str> = line.split_whitespace().collect();
+                if parts.len() >= 2 {
+                    let id = parts[0].parse::<i64>().unwrap_or(0);
+                    if parts.get(1) == Some(&"*") { active_id = Some(id); }
+                    spaces.push(serde_json::json!({ "id": id, "type": 0, "uuid": format!("desktop-{id}") }));
+                }
+            }
+            return Ok(serde_json::json!({
+                "supported": true,
+                "active_space_id": active_id,
+                "displays": [{ "display_id": "0", "spaces": spaces }],
+            }));
+        }
+        Ok(serde_json::json!({ "supported": false, "reason": "wmctrl not available" }))
+    }
+
+    #[napi]
+    pub fn get_active_space() -> napi::Result<serde_json::Value> {
+        let output = std::process::Command::new("wmctrl").args(["-d"]).output();
+        if let Ok(out) = output {
+            let text = String::from_utf8_lossy(&out.stdout);
+            for line in text.lines() {
+                let parts: Vec<&str> = line.split_whitespace().collect();
+                if parts.get(1) == Some(&"*") {
+                    let id = parts[0].parse::<i64>().unwrap_or(0);
+                    return Ok(serde_json::json!(id));
+                }
+            }
+        }
+        Ok(serde_json::json!(null))
+    }
+
+    #[napi]
+    pub fn create_agent_space() -> napi::Result<serde_json::Value> {
+        Ok(serde_json::json!({ "supported": false, "reason": "workspace creation not supported on Linux via this interface" }))
+    }
+
+    #[napi]
+    pub fn move_window_to_space(window_id: u32, space_id: u32) -> napi::Result<serde_json::Value> {
+        let status = std::process::Command::new("wmctrl")
+            .args(["-i", "-r", &format!("0x{:x}", window_id), "-t", &space_id.to_string()])
+            .status();
+        let moved = status.map(|s| s.success()).unwrap_or(false);
+        Ok(serde_json::json!({ "moved": moved, "reason": if moved { serde_json::Value::Null } else { serde_json::json!("wmctrl failed") } }))
+    }
+
+    #[napi]
+    pub fn remove_window_from_space(_window_id: u32, _space_id: u32) -> napi::Result<serde_json::Value> {
+        Ok(serde_json::json!({ "removed": false, "reason": "not supported on Linux" }))
+    }
+
+    #[napi]
+    pub fn destroy_space(_space_id: Option<u32>) -> napi::Result<serde_json::Value> {
+        Ok(serde_json::json!({ "destroyed": false, "reason": "workspace destruction not supported on Linux via this interface" }))
+    }
+}
+
 // ── macOS implementation ──────────────────────────────────────────────────────
 #[cfg(target_os = "macos")]
 #[path = "spaces_macos.rs"]

--- a/native/src/windows.rs
+++ b/native/src/windows.rs
@@ -1,3 +1,187 @@
+// ── Linux implementation ──────────────────────────────────────────────────────
+#[cfg(target_os = "linux")]
+mod platform {
+    use napi_derive::napi;
+    use std::process::Command;
+    use std::sync::OnceLock;
+
+    static IS_WAYLAND: OnceLock<bool> = OnceLock::new();
+
+    fn is_wayland() -> bool {
+        *IS_WAYLAND.get_or_init(|| {
+            std::env::var("XDG_SESSION_TYPE").map(|v| v == "wayland").unwrap_or(false)
+        })
+    }
+
+    fn gdbus_eval(js: &str) -> Option<String> {
+        let output = Command::new("gdbus").args([
+            "call", "--session",
+            "--dest", "org.gnome.Shell",
+            "--object-path", "/org/gnome/Shell",
+            "--method", "org.gnome.Shell.Eval",
+            js,
+        ]).output().ok()?;
+        let text = String::from_utf8_lossy(&output.stdout).to_string();
+        // Format: (true, 'json_string')
+        if text.starts_with("(true,") {
+            let start = text.find('\'')?;
+            let end = text.rfind('\'')?;
+            if start < end {
+                return Some(text[start+1..end].replace("\\'", "'"));
+            }
+        }
+        None
+    }
+
+    fn list_windows_wayland(bundle_id: &Option<String>) -> Vec<serde_json::Value> {
+        let js = r#"JSON.stringify(global.get_window_actors().map(a=>{let w=a.meta_window;let r=w.get_frame_rect();return{windowId:w.get_id(),bundleId:w.get_wm_class()||'',displayName:w.get_wm_class()||'',pid:w.get_pid(),title:w.get_title()||'',bounds:{x:r.x,y:r.y,width:r.width,height:r.height},isOnScreen:!w.minimized,isFocused:w.has_focus(),displayId:0}}))"#;
+        let json_str = match gdbus_eval(js) {
+            Some(s) => s,
+            None => return Vec::new(),
+        };
+        let windows: Vec<serde_json::Value> = serde_json::from_str(&json_str).unwrap_or_default();
+        if let Some(ref filter) = bundle_id {
+            windows.into_iter().filter(|w| {
+                let bid = w.get("bundleId").and_then(|v| v.as_str()).unwrap_or("");
+                bid.to_lowercase() == filter.to_lowercase()
+            }).collect()
+        } else {
+            windows
+        }
+    }
+
+    fn list_windows_x11(bundle_id: &Option<String>) -> Vec<serde_json::Value> {
+        let output = Command::new("wmctrl").args(["-l", "-p"]).output().unwrap_or_else(|_| {
+            Command::new("true").output().unwrap()
+        });
+        let text = String::from_utf8_lossy(&output.stdout);
+        let active = Command::new("xdotool").args(["getactivewindow"]).output().ok()
+            .and_then(|o| String::from_utf8_lossy(&o.stdout).trim().parse::<u32>().ok())
+            .unwrap_or(0);
+
+        let mut result = Vec::new();
+        for line in text.lines() {
+            let parts: Vec<&str> = line.splitn(5, char::is_whitespace).filter(|s| !s.is_empty()).collect();
+            if parts.len() < 4 { continue; }
+            let wid = u32::from_str_radix(parts[0].trim_start_matches("0x"), 16).unwrap_or(0);
+            let pid = parts[2].parse::<i32>().unwrap_or(0);
+            let title = if parts.len() >= 5 { parts[4].to_string() } else { String::new() };
+            let proc_name = std::fs::read_to_string(format!("/proc/{pid}/comm"))
+                .unwrap_or_default().trim().to_string();
+
+            if let Some(ref filter) = bundle_id {
+                if proc_name.to_lowercase() != filter.to_lowercase() { continue; }
+            }
+
+            result.push(serde_json::json!({
+                "windowId": wid,
+                "bundleId": proc_name,
+                "displayName": proc_name,
+                "pid": pid,
+                "title": title,
+                "bounds": { "x": 0, "y": 0, "width": 0, "height": 0 },
+                "isOnScreen": true,
+                "isFocused": wid == active,
+                "displayId": 0,
+            }));
+        }
+        result
+    }
+
+    #[napi]
+    pub fn list_windows(bundle_id: Option<String>) -> napi::Result<serde_json::Value> {
+        let result = if is_wayland() {
+            let mut wins = list_windows_wayland(&bundle_id);
+            if wins.is_empty() {
+                // Fall back to X11 tools via XWayland
+                wins = list_windows_x11(&bundle_id);
+            }
+            wins
+        } else {
+            list_windows_x11(&bundle_id)
+        };
+        Ok(serde_json::json!(result))
+    }
+
+    #[napi]
+    pub fn get_window(window_id: u32) -> napi::Result<serde_json::Value> {
+        if is_wayland() {
+            let js = format!(
+                r#"let w=global.get_window_actors().map(a=>a.meta_window).find(w=>w.get_id()==={wid});w?JSON.stringify({{windowId:w.get_id(),bundleId:w.get_wm_class()||'',displayName:w.get_wm_class()||'',pid:w.get_pid(),title:w.get_title()||'',bounds:(()=>{{let r=w.get_frame_rect();return{{x:r.x,y:r.y,width:r.width,height:r.height}}}})(),isOnScreen:!w.minimized,isFocused:w.has_focus(),displayId:0}}):'null'"#,
+                wid = window_id
+            );
+            if let Some(json_str) = gdbus_eval(&js) {
+                if json_str != "null" {
+                    if let Ok(val) = serde_json::from_str::<serde_json::Value>(&json_str) {
+                        return Ok(val);
+                    }
+                }
+            }
+        }
+        // X11 fallback
+        let output = Command::new("xdotool").args(["getwindowname", &window_id.to_string()]).output();
+        let title = output.ok().map(|o| String::from_utf8_lossy(&o.stdout).trim().to_string()).unwrap_or_default();
+        let pid_out = Command::new("xdotool").args(["getwindowpid", &window_id.to_string()]).output();
+        let pid = pid_out.ok().and_then(|o| String::from_utf8_lossy(&o.stdout).trim().parse::<i32>().ok()).unwrap_or(0);
+        let proc_name = std::fs::read_to_string(format!("/proc/{pid}/comm")).unwrap_or_default().trim().to_string();
+        if title.is_empty() && pid == 0 { return Ok(serde_json::json!(null)); }
+        Ok(serde_json::json!({
+            "windowId": window_id, "bundleId": proc_name, "displayName": proc_name,
+            "pid": pid, "title": title,
+            "bounds": { "x": 0, "y": 0, "width": 0, "height": 0 },
+            "isOnScreen": true, "isFocused": false, "displayId": 0,
+        }))
+    }
+
+    #[napi]
+    pub fn get_cursor_window() -> napi::Result<serde_json::Value> {
+        if is_wayland() {
+            let js = r#"let w=global.get_window_actors().map(a=>a.meta_window).find(w=>w.has_focus());w?JSON.stringify({windowId:w.get_id(),bundleId:w.get_wm_class()||'',displayName:w.get_wm_class()||'',pid:w.get_pid(),title:w.get_title()||'',bounds:(()=>{let r=w.get_frame_rect();return{x:r.x,y:r.y,width:r.width,height:r.height}})(),isOnScreen:!w.minimized,isFocused:true,displayId:0}):'null'"#;
+            if let Some(json_str) = gdbus_eval(js) {
+                if json_str != "null" {
+                    if let Ok(val) = serde_json::from_str::<serde_json::Value>(&json_str) {
+                        return Ok(val);
+                    }
+                }
+            }
+        }
+        // X11 fallback
+        let output = Command::new("xdotool").args(["getmouselocation", "--shell"]).output()
+            .map_err(|e| napi::Error::from_reason(format!("xdotool: {e}")))?;
+        let text = String::from_utf8_lossy(&output.stdout);
+        let wid = text.lines()
+            .find(|l| l.starts_with("WINDOW="))
+            .and_then(|l| l.strip_prefix("WINDOW="))
+            .and_then(|v| v.parse::<u32>().ok())
+            .unwrap_or(0);
+        if wid == 0 { return Ok(serde_json::json!(null)); }
+        get_window(wid)
+    }
+
+    #[napi]
+    pub fn activate_window(window_id: u32, _timeout_ms: Option<i32>) -> napi::Result<serde_json::Value> {
+        if is_wayland() {
+            let js = format!(
+                r#"let w=global.get_window_actors().map(a=>a.meta_window).find(w=>w.get_id()==={wid});if(w){{w.activate(global.get_current_time());'true'}}else{{'false'}}"#,
+                wid = window_id
+            );
+            let activated = gdbus_eval(&js).map(|s| s == "true").unwrap_or(false);
+            return Ok(serde_json::json!({
+                "windowId": window_id,
+                "activated": activated,
+                "reason": if activated { serde_json::Value::Null } else { serde_json::json!("window_not_found") },
+            }));
+        }
+        let status = Command::new("xdotool").args(["windowactivate", "--sync", &window_id.to_string()]).status();
+        let activated = status.map(|s| s.success()).unwrap_or(false);
+        Ok(serde_json::json!({
+            "windowId": window_id,
+            "activated": activated,
+            "reason": if activated { serde_json::Value::Null } else { serde_json::json!("raise_failed") },
+        }))
+    }
+}
+
 // ── macOS implementation ──────────────────────────────────────────────────────
 #[cfg(target_os = "macos")]
 #[path = "windows_macos.rs"]

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,16 +1,17 @@
 {
   "name": "@zavora-ai/computer-use-mcp",
-  "version": "6.0.0",
+  "version": "6.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@zavora-ai/computer-use-mcp",
-      "version": "6.0.0",
+      "version": "6.1.0",
       "license": "MIT",
       "os": [
         "darwin",
-        "win32"
+        "win32",
+        "linux"
       ],
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.12.1",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@zavora-ai/computer-use-mcp",
   "version": "6.1.0",
-  "description": "MCP server + client for cross-platform desktop control (macOS + Windows) — screenshot, mouse, keyboard, clipboard, app management. Backed by Rust NAPI native module.",
+  "description": "MCP server + client for cross-platform desktop control (macOS + Windows + Linux) — screenshot, mouse, keyboard, clipboard, app management. Backed by Rust NAPI native module.",
   "author": "James Karanja Maina <james@zavora.ai> (https://zavora.ai)",
   "license": "MIT",
   "type": "module",
@@ -10,7 +10,8 @@
   },
   "os": [
     "darwin",
-    "win32"
+    "win32",
+    "linux"
   ],
   "bin": {
     "computer-use-mcp": "dist/server.js"
@@ -41,6 +42,8 @@
     "computer-use-napi.node",
     "computer-use-napi.darwin-arm64.node",
     "computer-use-napi.darwin-x64.node",
+    "computer-use-napi.linux-x64.node",
+    "computer-use-napi.linux-arm64.node",
     "computer-use-napi.win32-x64.node",
     "README.md",
     "LICENSE"
@@ -48,6 +51,7 @@
   "scripts": {
     "build:native": "cd native && cargo build --release && cp target/release/libcomputer_use_napi.dylib ../computer-use-napi.darwin-$(uname -m | sed 's/x86_64/x64/' | sed 's/aarch64/arm64/').node && cp target/release/libcomputer_use_napi.dylib ../computer-use-napi.node",
     "build:native:win": "cd native && cargo build --release && copy target\\release\\computer_use_napi.dll ..\\computer-use-napi.win32-x64.node",
+    "build:native:linux": "cd native && cargo build --release && cp target/release/libcomputer_use_napi.so ../computer-use-napi.linux-$(uname -m | sed 's/x86_64/x64/' | sed 's/aarch64/arm64/').node && cp target/release/libcomputer_use_napi.so ../computer-use-napi.node",
     "build:ts": "tsc",
     "build": "npm run build:native && npm run build:ts",
     "test": "npm run build:ts && node --test test/*.test.mjs",

--- a/src/native.ts
+++ b/src/native.ts
@@ -16,6 +16,8 @@ const SUPPORTED_TARGETS: ReadonlyArray<{ platform: string; arch: string }> = [
   { platform: 'darwin', arch: 'arm64' },
   { platform: 'darwin', arch: 'x64' },
   { platform: 'win32', arch: 'x64' },
+  { platform: 'linux', arch: 'x64' },
+  { platform: 'linux', arch: 'arm64' },
 ]
 
 /**

--- a/src/session.ts
+++ b/src/session.ts
@@ -430,6 +430,7 @@ import * as path from 'path'
 
 const IS_WINDOWS = process.platform === 'win32'
 const IS_MACOS = process.platform === 'darwin'
+const IS_LINUX = process.platform === 'linux'
 
 const DEFAULT_LOCK_PATH = IS_WINDOWS
   ? path.join(os.tmpdir(), '.computer-use-mcp.lock')
@@ -536,7 +537,7 @@ function makeLockPumpController(
   let pumpInterval: NodeJS.Timeout | null = null
 
   function startPump() {
-    if (IS_WINDOWS) return  // No CFRunLoop on Windows
+    if (IS_WINDOWS || IS_LINUX) return  // No CFRunLoop on Windows/Linux
     if (pumpInterval != null) return
     pumpInterval = setInterval(() => {
       try { n.drainRunloop() } catch { /* never let the pump throw */ }
@@ -738,6 +739,9 @@ export function createSession(opts: SessionOptions = {}): Session {
       // On Windows, keep the terminal/IDE process visible
       return ['explorer.exe']
     }
+    if (IS_LINUX) {
+      return ['gnome-shell', 'gnome-terminal', 'xterm']
+    }
     const terminal = process.env.__CFBundleIdentifier
                   || process.env.TERM_PROGRAM_BUNDLE_ID
                   || 'com.apple.Terminal'
@@ -911,7 +915,7 @@ export function createSession(opts: SessionOptions = {}): Session {
   // ── v5: Scripting dictionary lookup + cache ─────────────────────────────
 
   async function findAppPath(bundleId: string): Promise<string | undefined> {
-    if (IS_WINDOWS) return undefined  // mdfind/sdef are macOS-only
+    if (IS_WINDOWS || IS_LINUX) return undefined  // mdfind/sdef are macOS-only
     // Try mdfind first (fast, indexed). Fall back to NSWorkspace is unnecessary
     // — we can simply let `sdef` fail if the app is missing.
     const r = await spawnBounded(
@@ -983,7 +987,7 @@ export function createSession(opts: SessionOptions = {}): Session {
   }
 
   async function yabaiAvailable(): Promise<boolean> {
-    if (IS_WINDOWS) return false
+    if (IS_WINDOWS || IS_LINUX) return false
     const r = await spawnBounded('yabai', ['--version'], 3_000)
     return r.code === 0
   }
@@ -1042,7 +1046,7 @@ export function createSession(opts: SessionOptions = {}): Session {
   }
 
   async function tryCreateSpaceWithMissionControl(): Promise<Record<string, unknown> | undefined> {
-    if (IS_WINDOWS || typeof n.listSpaces !== 'function') return undefined
+    if (IS_WINDOWS || IS_LINUX || typeof n.listSpaces !== 'function') return undefined
     const before = n.listSpaces()
     const beforeList = Array.isArray(before.displays)
       ? before.displays.flatMap((d: any) => Array.isArray(d.spaces) ? d.spaces : [])
@@ -1185,6 +1189,21 @@ export function createSession(opts: SessionOptions = {}): Session {
         return spawnBounded(exe, ['-NoProfile', '-NonInteractive', '-EncodedCommand', encoded], timeoutMs)
       }
       return spawnBounded(exe, ['-NoProfile', '-NonInteractive', '-Command', script], timeoutMs)
+    }
+    if (IS_LINUX) {
+      if (language === 'applescript' || language === 'javascript') {
+        return {
+          stdout: '',
+          stderr: `${language} is not supported on Linux. Use language: "bash" or "powershell" instead.`,
+          code: 1,
+          timedOut: false,
+        }
+      }
+      if (language === 'powershell') {
+        return spawnBounded('pwsh', ['-NoProfile', '-NonInteractive', '-Command', script], timeoutMs)
+      }
+      // Default to bash on Linux
+      return spawnBounded('bash', ['-c', script], timeoutMs)
     }
     // macOS: osascript
     const args = language === 'javascript'
@@ -1487,7 +1506,7 @@ export function createSession(opts: SessionOptions = {}): Session {
 
           // clear: select all + delete before typing
           if (args.clear === true || args.clear === 'true') {
-            n.keyPress(IS_WINDOWS ? 'ctrl+a' : 'command+a')
+            n.keyPress((IS_WINDOWS || IS_LINUX) ? 'ctrl+a' : 'command+a')
             await sleep(30)
             n.keyPress('delete')
             await sleep(30)
@@ -1495,12 +1514,12 @@ export function createSession(opts: SessionOptions = {}): Session {
 
           if (text.length > 100) {
             // Clipboard-based typing: faster and more reliable for long text
-            if (IS_WINDOWS && n.readClipboard && n.writeClipboard) {
+            if ((IS_WINDOWS || IS_LINUX) && n.readClipboard && n.writeClipboard) {
               let saved: string | undefined
               try { saved = n.readClipboard() } catch { /* ignore */ }
               try {
                 n.writeClipboard(text)
-                n.keyPress('ctrl+v')
+                n.keyPress(IS_LINUX ? 'ctrl+v' : 'ctrl+v')
                 await sleep(100)
               } finally {
                 if (typeof saved === 'string') {
@@ -1560,14 +1579,14 @@ export function createSession(opts: SessionOptions = {}): Session {
 
         // ── Clipboard ────────────────────────────────────────────────────────
         case 'read_clipboard': {
-          if (IS_WINDOWS && n.readClipboard) {
+          if ((IS_WINDOWS || IS_LINUX) && n.readClipboard) {
             return ok(n.readClipboard())
           }
           const text = execFileSync('pbpaste', []).toString()
           return ok(text)
         }
         case 'write_clipboard': {
-          if (IS_WINDOWS && n.writeClipboard) {
+          if ((IS_WINDOWS || IS_LINUX) && n.writeClipboard) {
             n.writeClipboard(str('text'))
             return ok('Written')
           }
@@ -2386,7 +2405,8 @@ export function createSession(opts: SessionOptions = {}): Session {
                 'Get-Process | Sort-Object WorkingSet64 -Descending | Select-Object -First 20 Id,ProcessName,@{N="MemMB";E={[math]::Round($_.WorkingSet64/1MB,1)}} | ConvertTo-Json'], 10000)
               return r.code === 0 ? ok(r.stdout) : { content: [{ type: 'text', text: r.stderr }], isError: true }
             } else {
-              const r = await spawnBounded('ps', ['aux', '-r'], 5000)
+              const psArgs = IS_LINUX ? ['aux', '--sort=-%mem'] : ['aux', '-r']
+              const r = await spawnBounded('ps', psArgs, 5000)
               const lines = r.stdout.split('\n').slice(0, 21)
               return ok(lines.join('\n'))
             }


### PR DESCRIPTION
## Summary

Adds native Linux backend to computer-use-mcp, making it a true cross-platform desktop automation server (macOS + Windows + Linux).

## What was added

### Rust native module (`native/src/`)
- **Mouse** — X11/XTest (X11) or ydotool (Wayland)
- **Keyboard** — X11/XTest keycodes or ydotool evdev keycodes
- **Text input** — xdotool type (X11) or ydotool type (Wayland)
- **Screenshots** — XDG Desktop Portal (GNOME Wayland), grim (wlroots), scrot (X11)
- **Clipboard** — wl-copy/wl-paste (Wayland) or xclip/xsel (X11)
- **Windows** — GNOME Shell D-Bus (Wayland) or wmctrl (X11)
- **Apps** — /proc + wmctrl + GNOME D-Bus
- **Display** — X11 XDisplayWidth/XDisplayHeight
- **Workspaces** — wmctrl
- **Accessibility** — stubs (AT-SPI2 planned)

### TypeScript changes
- `src/native.ts` — added linux-x64 and linux-arm64 targets
- `src/session.ts` — IS_LINUX constant, clipboard, scripting (bash), keyboard handling

### Wayland-native support
- Runtime detection via `XDG_SESSION_TYPE`
- Auto-fallback: Wayland tools → X11/XWayland
- Tested on GNOME 50 (Ubuntu 25.04)

## What was tested
- ✅ Native module compiles cleanly (0 warnings)
- ✅ All 36 NAPI functions load
- ✅ Screenshot via XDG Portal (real Wayland capture)
- ✅ Mouse movement via ydotool
- ✅ Keyboard input and text typing
- ✅ Clipboard round-trip (wl-copy/wl-paste)
- ✅ Form filling on zavora.ai (signup completed successfully)
- ✅ Terminal automation (opened terminal, ran commands)
- ✅ MCP server starts and responds to tool calls

## Zero impact on existing platforms
- All Rust code gated behind `#[cfg(target_os = "linux")]`
- All TS code gated behind `IS_LINUX` checks
- macOS and Windows paths completely untouched

## Dependencies (Linux only)
- Build: `pkg-config`, `libx11-dev`, `libxtst-dev`, `libxrandr-dev`
- Runtime (X11): `xdotool`, `wmctrl`, `xclip`, `scrot`
- Runtime (Wayland): `ydotool`, `wl-clipboard`, `grim`